### PR TITLE
Turn UseSQLite3 to true, if TableName specified

### DIFF
--- a/DHT.cs
+++ b/DHT.cs
@@ -26,6 +26,8 @@ namespace DHT
 		public static KeyValue hashtable = null;
 		
 		public DHT(){ //args may be already defined
+			//Set this value in KeyValue-Method
+			//Storage.KeyValue.UseSQLite3 = true;	//use SQLite3 db, with defined values.
 			hashtable = new KeyValue(DBFilePath, HashTableName, KeyName, ValueName);	//use sqlite, with values
 		}
 		

--- a/KeyValue.cs
+++ b/KeyValue.cs
@@ -85,6 +85,13 @@ namespace Storage
 			,	string ValueName = null
 		){
 			Console.WriteLine("KeyValue: "+DbFileName+", "+KeyValueTableName+", "+KeyName+", "+ValueName);
+			if(String.IsNullOrEmpty(KeyValueTableName)){
+				UseSQLite3 = false;
+			}
+			else{
+				UseSQLite3 = true;
+			}
+			Console.WriteLine("UseSQLite3 = "+UseSQLite3);
 			
 			//on initialize object, just initialize this
 			hashtable = Load(DbFileName, KeyValueTableName, KeyName, ValueName); //and load hashtable from storage


### PR DESCRIPTION
Turn UseSQLite3 to true, if TableName specified.
Now, string variales, in DHT.cs, can be defined, and program can be runned by double-click, without arguments.