### PR TITLE
Set sync intervals from cmd arguments

### DIFF
--- a/DHT.cs
+++ b/DHT.cs
@@ -309,7 +309,7 @@ namespace DHT
 		}
 		
 		//set interval for sync DHT from peers
-		public static int SyncDHTInterval = 30; //seconds to repeat send UDP MultiCast request to discovery peers.
+		public static int SyncDHTInterval = 60; //seconds to repeat send UDP MultiCast request to discovery peers.
 
 		//Define timer, to repeat synchronizatino from peers.
 		public static System.Timers.Timer syncDHTTimer = null;	

--- a/LocalPeerDiscovery.cs
+++ b/LocalPeerDiscovery.cs
@@ -14,7 +14,7 @@ namespace Peer
 	public class LocalPeersDiscovery
 	{
 		//set interval for Peer Discovery
-		public static int PeerDiscoveryInterval = 1; //seconds to repeat send UDP MultiCast request to discovery peers.
+		public static int PeerDiscoveryInterval = 300; //seconds to repeat send UDP MultiCast request to discovery peers.
 		
 		//Method to run Peer Discovery
 		public static void DiscoveryPeers(){
@@ -41,6 +41,8 @@ namespace Peer
 				Console.WriteLine("PeerDiscoveryInterval = 0, so LocalPeerDiscovery was been disabled.");
 				return;
 			}
+			
+			DiscoveryPeers();	//run before timer elapsed
 			
 			//run interval
 			aTimer = new System.Timers.Timer( PeerDiscoveryInterval * 1000 );

--- a/Peer.bat
+++ b/Peer.bat
@@ -6,12 +6,12 @@ set program=Peer
 
 %csc% /out:%program%.exe *.cs /reference:Mono.Data.Sqlite.dll /reference:sqlite3.dll /platform:x86
 
-::Peer.exe IP port MulticastGroupIP PeerDiscoveryInterval DBFilePath TableName KeyName ValueName
+::Peer.exe IP port MulticastGroupIP PeerDiscoveryInterval SyncDHTInterval DBFilePath TableName KeyName ValueName
 
 ::SQLite3 storage
-%program%.exe 0.0.0.0 8081 235.5.5.11 15 Hashtable.db3 KeyValue key value
+%program%.exe 0.0.0.0 8081 235.5.5.11 15 30 Hashtable.db3 KeyValue key value
 
 ::Simple TXT storage
-::%program%.exe 0.0.0.0 8081 235.5.5.11 15 Hashtable.txt
+::%program%.exe 0.0.0.0 8081 235.5.5.11 15 30 Hashtable.txt
 
 pause

--- a/Peer.cs
+++ b/Peer.cs
@@ -55,18 +55,17 @@ namespace Peer
 		private static int		port					=	8082				;	//port
 		private static string	UDPMultiCastGroupIP		=	"235.5.5.11"		;	//Multicast Group IP
 		private static string	localhost				=	"127.0.0.1"			;
-		private static int		PeerDiscoveryInterval	=	15									;	//seconds
 
 		public static void Main(string[] args)
 		{
 			Console.WriteLine(
 				@"Usage:
 	Use SQLite3 database:
-Peer.exe IP port MulticastGroupIP PeerDiscoveryInterval DBFilePath TableName KeyName ValueName
+Peer.exe IP port MulticastGroupIP PeerDiscoveryInterval SyncDHTInterval DBFilePath TableName KeyName ValueName
 	or use txt-file instead:
-Peer.exe IP port MulticastGroupIP PeerDiscoveryInterval TXTFilePath
+Peer.exe IP port MulticastGroupIP PeerDiscoveryInterval SyncDHTInterval TXTFilePath
 	or disable LDP
-Peer.exe IP port someIP 0 DBFilePath TableName KeyName ValueName
+Peer.exe IP port someIP 0 SyncDHTInterval DBFilePath TableName KeyName ValueName
 "
 			);
 			Console.WriteLine("Press any key, to continue...");
@@ -84,9 +83,10 @@ Peer.exe IP port someIP 0 DBFilePath TableName KeyName ValueName
 				port = System.Int32.Parse(args[1]);
 			}
 			
-			//next 6 arguments:
+			//next 7 arguments:
 			//	UDPMultiCastGroupIP
 			//	PeerDiscoveryInterval,
+			//	SyncDHTInterval,
 			//	sqlite3 path,
 			//	TableOrViewName,
 			//	KeyName,
@@ -94,24 +94,30 @@ Peer.exe IP port someIP 0 DBFilePath TableName KeyName ValueName
 			if(args.Length > 2){	//Multicast Group IP
 				UDPMultiCastGroupIP = args[2];
 			}
+			
+			//intervals
 			if(args.Length > 3){
-				PeerDiscoveryInterval = System.Int32.Parse(args[3]);	//PeerDiscoveryInterval, seconds
-				Console.WriteLine("New PeerDiscoveryInterval = "+PeerDiscoveryInterval);
+				LocalPeersDiscovery.PeerDiscoveryInterval = System.Int32.Parse(args[3]);	//PeerDiscoveryInterval, seconds
+				Console.WriteLine("New LocalPeersDiscovery.PeerDiscoveryInterval = "+LocalPeersDiscovery.PeerDiscoveryInterval);
+			}
+			if(args.Length > 4){
+				DHT.DHT_client.SyncDHTInterval = System.Int32.Parse(args[4]);	//SyncDHTInterval, seconds
+				Console.WriteLine("New DHT.DHT_client.SyncDHTInterval = "+DHT.DHT_client.SyncDHTInterval);
 			}
 			
 			//DHT args
-			if(args.Length > 4){
-				DHT.DHT.DBFilePath = args[4];	//sqlite3 or txt Database Path
-			}
 			if(args.Length > 5){
-				Storage.KeyValue.UseSQLite3 = true;	//enable SQLite3
-				DHT.DHT.HashTableName = args[5];	//HashTable or View Name in SQLite3 database
+				DHT.DHT.DBFilePath = args[5];	//sqlite3 or txt Database Path
 			}
 			if(args.Length > 6){
-				DHT.DHT.KeyName = args[6];		//KeyName in HashTable in SQLite3 database
+				Storage.KeyValue.UseSQLite3 = true;	//enable SQLite3
+				DHT.DHT.HashTableName = args[6];	//HashTable or View Name in SQLite3 database
 			}
 			if(args.Length > 7){
-				DHT.DHT.ValueName = args[7];	//ValueName in HashTable in SQLite3 database
+				DHT.DHT.KeyName = args[7];		//KeyName in HashTable in SQLite3 database
+			}
+			if(args.Length > 8){
+				DHT.DHT.ValueName = args[8];	//ValueName in HashTable in SQLite3 database
 			}
 			
 			Addnode.DefaultPort = port;
@@ -119,7 +125,7 @@ Peer.exe IP port someIP 0 DBFilePath TableName KeyName ValueName
 		//raise KeyValue HashTable for DHT, with previous args.
 		
 		//DHT.DHT.RunDHT(args[4], args[5], args[6], args[7]);		//raise KeyValue HashTable for DHT, with previous args.
-		//DHT.DHT.RunDHT(args.Skip(4).ToArray()); //last 4 args
+		//DHT.DHT.RunDHT(args.Skip(5).ToArray()); //last 4 args
 		DHT.DHT dht = new DHT.DHT();	//just raise with already defined.
 		
 
@@ -216,7 +222,7 @@ Peer.exe IP port someIP 0 DBFilePath TableName KeyName ValueName
 
 				Console.WriteLine("\n\n" +	"Run interval for LDP (Local Peer Discovery)... ");
 //				//Run interval for LDP (Local Peer Discovery)
-				LocalPeersDiscovery.RunDiscoveryPeersInterval(5);	//seconds
+				LocalPeersDiscovery.RunDiscoveryPeersInterval();	//seconds
 			
 			
 			

--- a/Peer.sh
+++ b/Peer.sh
@@ -3,7 +3,7 @@ csc /out:Peer.exe *.cs /reference:Mono.Data.Sqlite.dll /reference:sqlite3.dll /p
 #Peer.exe IP port MulticastGroupIP PeerDiscoveryInterval DBFilePath TableName KeyName ValueName
 
 #SQLite3 storage
-%program%.exe 0.0.0.0 8081 235.5.5.11 15 Hashtable.db3 KeyValue key value
+%program%.exe 0.0.0.0 8081 235.5.5.11 15 30 Hashtable.db3 KeyValue key value
 
 #Simple TXT storage
-%program%.exe 0.0.0.0 8081 235.5.5.11 15 Hashtable.txt
+%program%.exe 0.0.0.0 8081 235.5.5.11 15 30 Hashtable.txt


### PR DESCRIPTION
DHT.cs - change value of SyncDHTInterval to 60 seconds.

LocalPeerDiscovery.cs - change value of PeerDiscoveryInterval to 300 seconds, and run DiscoveryPeers(); before timer interval elapsed.

Peer.cs - remove PeerDiscoveryInterval (this already exists as LocalPeersDiscovery.PeerDiscoveryInterval ), add DHT.DHT_client.SyncDHTInterval as argument, fix usage text, amd run LocalPeersDiscovery.RunDiscoveryPeersInterval() without any value (this value already defined or redefined frmo cmd arguments).

Peer.bat, Peer.sh - add SyncDHTInterval as agrument.